### PR TITLE
Return ruleSet.getSelectors() as list from array

### DIFF
--- a/src/co/uproot/css/domimpl/CSSUtils.java
+++ b/src/co/uproot/css/domimpl/CSSUtils.java
@@ -42,7 +42,7 @@ final class CSSUtils {
     final StyleSheet jSheet = parse(selectorText + "{}");
     if (jSheet.size() > 0) {
       final RuleSet ruleSet = (RuleSet) jSheet.get(0);
-      return ruleSet.getSelectors();
+      return Arrays.asList(ruleSet.getSelectors());
     }
     return new ArrayList<CombinedSelector>();
   }


### PR DESCRIPTION
This returns the ruleSet.getSelectors() array as a list sense the update that made it return an array.
